### PR TITLE
Fix lipsync TTS audio context error

### DIFF
--- a/src/services/lipsyncTTSService.js
+++ b/src/services/lipsyncTTSService.js
@@ -705,13 +705,8 @@ class LipsyncTTSService {
     
     // Try to stop any Web Audio API contexts that might be running
     try {
-      if (window.AudioContext) {
-        // This is a more aggressive approach - we'll try to find and suspend any active audio contexts
-        const contextState = AudioContext.prototype.state;
-        if (contextState === 'running') {
-          console.log('Attempting to suspend active audio contexts');
-        }
-      }
+      // Removed problematic AudioContext.prototype.state access to avoid Illegal invocation error
+      // If you have references to created AudioContext instances, close or suspend them here
     } catch (error) {
       console.warn('Error handling audio contexts:', error);
     }


### PR DESCRIPTION
Remove `AudioContext.prototype.state` access to fix 'Illegal invocation' TypeError.

The `TypeError: Illegal invocation` occurred because `AudioContext.prototype.state` is not a valid way to access the state of an audio context; `state` is a property of an `AudioContext` instance. This error prevented the `emergencyStop` function from completing its error handling, which was reported to be related to STT AI response generation issues.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e60926fd-fb80-4096-a377-bd989fe240eb) · [Cursor](https://cursor.com/background-agent?bcId=bc-e60926fd-fb80-4096-a377-bd989fe240eb)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)